### PR TITLE
feat(observabilidad): instrumentar métricas Prometheus en servicio sedes

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,3 +15,10 @@
 - Servicio `assign_profesor_sede` y `get_sedes_by_profesor` con validación de `auth_api`.
 - Endpoint **POST** `/sedes/profesor_sede/` para asignar un profesor a una sede.
 - Endpoint **GET** `/sedes/por_profesor/{id_profesor}` para listar sedes asignadas a un profesor.
+
+## [1.2.0] - 2025-07-08
+### Agregado
+- Instrumentación Prometheus: contador de peticiones, histograma de latencia (buckets ajustados), contador de errores y endpoint `/metrics`.
+- Configuración de Prometheus (`prometheus.yml`) para scrapear el servicio de sedes.
+- Pruebas de integración para endpoints CRUD de sedes y rutas `profesor_sede`.
+- Script de generación de reporte PDF de resultados de pruebas.

--- a/app/main.py
+++ b/app/main.py
@@ -1,9 +1,11 @@
 import logging
 from contextlib import asynccontextmanager
 
-from fastapi import FastAPI
+from fastapi import FastAPI,  Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 
+import time
+from prometheus_client import Counter, Histogram, CollectorRegistry, generate_latest, CONTENT_TYPE_LATEST
 from app.config import settings
 from app.db import init_db, test_connection
 from app.routers import sedes
@@ -24,6 +26,25 @@ app = FastAPI(
     lifespan=lifespan
 )
 
+# ── 2. Definición de métricas Prometheus ────────────────────────────────────────
+REQUEST_COUNT_SEDES = Counter(
+    "http_requests_total_sedes",
+    "Total de peticiones HTTP al servicio de sedes",
+    ["method", "endpoint"]
+)
+REQUEST_LATENCY_SEDES = Histogram(
+    "http_request_duration_seconds_sedes",
+    "Duración de las peticiones HTTP al servicio de sedes",
+    ["method", "endpoint"],
+    buckets=[0.05, 0.1, 0.2, 0.3, 1.0, 2.5, 5.0]
+)
+ERROR_COUNT_SEDES = Counter(
+    "http_request_errors_total_sedes",
+    "Total de errores HTTP (status >= 400) en servicio de sedes",
+    ["method", "endpoint", "status_code"]
+)
+
+
 app.add_middleware(
     CORSMiddleware,
     allow_origins=settings.CORS_ORIGINS,
@@ -33,6 +54,43 @@ app.add_middleware(
 )
 
 app.include_router(sedes.router, prefix="/sedes", tags=["Sedes"])
+
+# ── 3. Middleware para capturar métricas ────────────────────────────────────────
+@app.middleware("http")
+async def metrics_middleware(request: Request, call_next):
+    start_time = time.time()
+    try:
+        response = await call_next(request)
+        status = response.status_code
+    except Exception:
+        status = 500
+        raise
+    finally:
+        latency = time.time() - start_time
+        endpoint = request.url.path
+        method = request.method
+
+        REQUEST_COUNT_SEDES.labels(method=method, endpoint=endpoint).inc()
+        REQUEST_LATENCY_SEDES.labels(method=method, endpoint=endpoint).observe(latency)
+        if status >= 400:
+            ERROR_COUNT_SEDES.labels(
+                method=method,
+                endpoint=endpoint,
+                status_code=str(status)
+            ).inc()
+
+    return response
+
+# ── 4. Endpoint /metrics para Prometheus ───────────────────────────────────────
+@app.get("/metrics")
+def custom_metrics():
+    registry = CollectorRegistry()
+    registry.register(REQUEST_COUNT_SEDES)
+    registry.register(REQUEST_LATENCY_SEDES)
+    registry.register(ERROR_COUNT_SEDES)
+    data = generate_latest(registry)
+    return Response(data, media_type=CONTENT_TYPE_LATEST)
+
 
 if __name__ == "__main__":
     import uvicorn

--- a/deployment/prometheus/prometheus.yml
+++ b/deployment/prometheus/prometheus.yml
@@ -1,0 +1,30 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']
+
+  - job_name: 'sedes_service'
+    metrics_path: /metrics
+    static_configs:
+      - targets: ['localhost:8000']
+
+#Para ejecutar en la terminal
+#prometheus --config.file=deployment/prometheus/prometheus.yml
+
+#Ver las gráficas
+
+# Arranca la API (uvicorn app.main:app --reload).
+
+# En el navegador ve a http://localhost:9090/targets y comprueba que sedes_service esté UP.
+
+# En http://localhost:9090/graph, ejecuta queries como
+
+# http_requests_total_sedes_total
+# rate(http_requests_total_sedes_total[1m])
+# rate(http_request_duration_seconds_sedes_sum[1m]) / rate(http_request_duration_seconds_sedes_count[1m])
+# increase(http_request_errors_total_sedes_total[1m])
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-fastapi==0.95.2
+# fastapi==0.95.2
+fastapi>=0.100.0,<0.115.0
 uvicorn==0.22.0
 sqlalchemy==1.4.46
 pydantic>=2.11,<3
@@ -10,6 +11,8 @@ pycparser==2.22
 python-jose[cryptography]
 httpx>=0.24.0,<1
 requests>=2.0.0
+prometheus-client==0.16.0
+
 
 
 


### PR DESCRIPTION
**Historia**: OBSERVABILIDAD-SEDES  
Como líder de desarrollo, quiero monitorear las peticiones, tiempos de respuesta y errores de endpoint en el servicio sedes, para así tener información respecto a su rendimiento.

**Cambios realizados**:
1. Instrumentación de la API en `app/main.py` usando prometheus_client:
   - Counter de peticiones HTTP.
   - Histogram de latencia con buckets (50 ms–5 s).
   - Counter de errores HTTP (status ≥ 400).
   - Endpoint `/metrics`.
2. Añadido `deployment/prometheus/prometheus.yml` con scrape_configs para los jobs `prometheus` y `sedes_service`.
3. Actualizado `requirements.txt` y `Changelog.md` con la nueva versión **1.2.0** y detalles de la observabilidad.

**Verificación**:
- Al arrancar la API (`uvicorn app.main:app --reload`) y Prometheus:
  - `/metrics` expone las métricas.
  - `http://localhost:9090/targets` muestra ambos jobs **UP**.
  - `http://localhost:9090/graph` permite ejecutar queries de conteo, tasa, latencia y errores en tiempo real.

**Estado**: Listo para revisión y merge a `develop`.
